### PR TITLE
fix(api/src/routes/order): fix orders to be sorted in reverse chronol…

### DIFF
--- a/api/src/database/seeders/20210621225730-orders.js
+++ b/api/src/database/seeders/20210621225730-orders.js
@@ -123,7 +123,7 @@ module.exports = {
 
     const cart01 = {
       personId: customers[0].id,
-      status: "paid",
+      status: "completed",
       paymentMethod: "Stripe",
       total: 999,
       createdAt: new Date(),
@@ -132,7 +132,7 @@ module.exports = {
 
     const cart02 = {
       personId: customers[0].id,
-      status: "paid",
+      status: "completed",
       paymentMethod: "MercadoPago",
       total: 2000,
       createdAt: new Date(),
@@ -150,7 +150,7 @@ module.exports = {
 
     const cart04 = {
       personId: customers[1].id,
-      status: "created",
+      status: "completed",
       paymentMethod: "none",
       total: 10000,
       createdAt: new Date(),

--- a/api/src/routes/orders.js
+++ b/api/src/routes/orders.js
@@ -185,6 +185,7 @@ router.get('/', async (req, res) => {
             const orders = await models.Cart.findAll({
                 limit: limit,
                 offset: (page * limit) - limit,
+                order: [['id', 'DESC']]
             });
 
             return response.success(req, res, { ...data, count, pages, pageNumber, orders }, 200);
@@ -209,6 +210,7 @@ router.get('/', async (req, res) => {
             where: { status: status },
             limit: limit,
             offset: (page * limit) - limit,
+            order: [['id', 'DESC']]
         });
 
         response.success(req, res, { ...data, count, pages, pageNumber, orders }, 200);


### PR DESCRIPTION
- Fixed GET ORDERS endpoint to show orders in reverse chronological order (latest orders show up first).
- Changed the status of all seeder orders to "completed"